### PR TITLE
fix the formatting of examples.json (make it valid)

### DIFF
--- a/static/examples.json
+++ b/static/examples.json
@@ -6898,7 +6898,7 @@
               "type": "string",
               "description": "The content of the comment."
             }
-          },
+          }
         }
       }
     },


### PR DESCRIPTION
There is an extra "," in the json that is making it invalid.